### PR TITLE
Update base image to v2.13

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM pandoc/latex:2.9.2
+FROM pandoc/latex:2.13
 
 RUN tlmgr list
 RUN tlmgr update --self && \


### PR DESCRIPTION
Pandoc 2.12+ is [required](https://github.com/pandoc/lua-filters/commit/d7c791d54e1a90a122ef6839e66991ec15b041d1#diff-af7df85768df2036ad319f384a57cc4d88ae4549d59804ce96d0b3cb4c8333e1) to use the latest version of Pandoc's semi-official Lua filter [**include-files**](https://github.com/pandoc/lua-filters/tree/master/include-files), which is currently the most straight-forward way to use child documents in Pandoc Markdown.